### PR TITLE
Feat/#11 카테고리 페이지에 페이지네이션 구축

### DIFF
--- a/components/BlogContents.tsx
+++ b/components/BlogContents.tsx
@@ -1,0 +1,14 @@
+export default function BlogContents({ post, MDXComponent }) {
+  return (
+    <article className="mt-10 prose max-w-none">
+      <h1 className="text-green-500 text-center">{post.title}</h1>
+      <h3 className="text-green-600 text-end italic">
+        {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
+        {post.date.slice(8, 10)}일
+      </h3>
+      <article className={`w-full dark:text-slate-50 text-neutral-900`}>
+        <MDXComponent />
+      </article>
+    </article>
+  );
+}

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-const BlogPost = ({ date, title, des, slug }) => {
+export default function BlogPost({ date, title, des, slug }) {
   return (
     <div className="w-full my-7 transition ease-in-out hover:-translate-x-1.5 hover:text-green-400/80">
       <Link href={`/${slug}`} passHref>
@@ -12,6 +12,4 @@ const BlogPost = ({ date, title, des, slug }) => {
       </Link>
     </div>
   );
-};
-
-export default BlogPost;
+}

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 
-const Comments = () => {
+export default function Comments() {
   const ref = useRef(null);
 
   useEffect(() => {
@@ -16,6 +16,4 @@ const Comments = () => {
   }, []);
 
   return <div ref={ref}></div>;
-};
-
-export default Comments;
+}

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -9,7 +9,7 @@ import Nav from "components/Nav";
 import NextProgress from "next-progress";
 import ProgressBar from "react-scroll-progress-bar";
 
-const Container = (props) => {
+export default function Container(props) {
   const meta = {
     type: metadata.type,
     title: metadata.title,
@@ -71,6 +71,4 @@ const Container = (props) => {
       <section className={`w-full max-w-3xl mt-10`}>{props.children}</section>
     </main>
   );
-};
-
-export default Container;
+}

--- a/components/Container.tsx
+++ b/components/Container.tsx
@@ -59,7 +59,7 @@ export default function Container(props) {
               className={`rounded-full hover:animate-spin`}
             />
             <span
-              className={`mx-3 font-semibold italic text-lg text-green-400`}
+              className={`mx-3 font-semibssold italic text-lg text-green-400`}
             >
               Kang blog
             </span>

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -8,7 +8,7 @@ import navlinks from "data/navlinks";
 
 import { allAlgorithms } from "contentlayer/generated";
 
-const Nav = () => {
+export default function Nav() {
   const path = useRouter().pathname;
 
   const [menu, setMenu] = useState(false);
@@ -91,6 +91,4 @@ const Nav = () => {
       </div>
     </nav>
   );
-};
-
-export default Nav;
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -6,8 +6,6 @@ import Image from "next/image";
 
 import navlinks from "data/navlinks";
 
-import { allAlgorithms } from "contentlayer/generated";
-
 export default function Nav() {
   const path = useRouter().pathname;
 

--- a/components/Pagnation.tsx
+++ b/components/Pagnation.tsx
@@ -6,7 +6,11 @@ interface PagnationProps {
   curPage: number;
 }
 
-const Pagnation = ({ pageCount, setCurPage, curPage }: PagnationProps) => {
+export default function Pagnation({
+  pageCount,
+  setCurPage,
+  curPage,
+}: PagnationProps) {
   const onChangePage = (e) => {
     setCurPage(+e.target.innerText);
   };
@@ -38,6 +42,4 @@ const Pagnation = ({ pageCount, setCurPage, curPage }: PagnationProps) => {
       <ul className="flex">{pageArray}</ul>
     </nav>
   );
-};
-
-export default Pagnation;
+}

--- a/components/Pagnation.tsx
+++ b/components/Pagnation.tsx
@@ -20,6 +20,7 @@ export default function Pagnation({
     if (curPage === i) {
       pageArray.push(
         <li
+          key={i}
           onClick={onChangePage}
           className=" py-1 px-2 leading-tight text-gray-500 bg-red-300 border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-600 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white hover:cursor-pointer"
         >
@@ -29,6 +30,7 @@ export default function Pagnation({
     } else {
       pageArray.push(
         <li
+          key={i}
           onClick={onChangePage}
           className="py-1 px-2 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white hover:cursor-pointer"
         >

--- a/components/Pagnation.tsx
+++ b/components/Pagnation.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface PagnationProps {
+  pageCount: number;
+  setCurPage: (page: number) => void;
+  curPage: number;
+}
+
+const Pagnation = ({ pageCount, setCurPage, curPage }: PagnationProps) => {
+  const onChangePage = (e) => {
+    setCurPage(+e.target.innerText);
+  };
+
+  const pageArray = [];
+  for (let i = 1; i < pageCount + 1; i++) {
+    if (curPage === i) {
+      pageArray.push(
+        <li
+          onClick={onChangePage}
+          className=" py-1 px-2 leading-tight text-gray-500 bg-red-300 border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-600 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white hover:cursor-pointer"
+        >
+          {i}
+        </li>
+      );
+    } else {
+      pageArray.push(
+        <li
+          onClick={onChangePage}
+          className="py-1 px-2 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white hover:cursor-pointer"
+        >
+          {i}
+        </li>
+      );
+    }
+  }
+  return (
+    <nav className="flex justify-center">
+      <ul className="flex">{pageArray}</ul>
+    </nav>
+  );
+};
+
+export default Pagnation;

--- a/components/PostList.tsx
+++ b/components/PostList.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import BlogPost from "components/BlogPost";
 
-const PostList = ({ searchPosts, posts }) => {
+export default function PostList({ searchPosts, posts }) {
   return (
     <article className={`mt-20 flex flex-col`}>
       {searchPosts.length ? (
@@ -31,6 +31,4 @@ const PostList = ({ searchPosts, posts }) => {
       )}
     </article>
   );
-};
-
-export default PostList;
+}

--- a/components/SeachBar.tsx
+++ b/components/SeachBar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-const SeachBar = ({ searchTitle, onChangeSearchTitle }) => {
+export default function SeachBar({ searchTitle, onChangeSearchTitle }) {
   return (
     <form className={`fixed w-4/5 max-w-2xl flex mt-4`}>
       <input
@@ -12,6 +12,4 @@ const SeachBar = ({ searchTitle, onChangeSearchTitle }) => {
       />
     </form>
   );
-};
-
-export default SeachBar;
+}

--- a/components/TopBtn.tsx
+++ b/components/TopBtn.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
-const TopBtn = () => {
+export default function TopBtn() {
   const [isScroll, setIsScroll] = useState(false);
 
   useEffect(() => {
@@ -31,6 +31,4 @@ const TopBtn = () => {
       )}
     </>
   );
-};
-
-export default TopBtn;
+}

--- a/hooks/usePagnationPosts.ts
+++ b/hooks/usePagnationPosts.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+export default function usePagnationPosts({ posts }) {
+  const [curPage, setCurPage] = useState(1);
+  const LIMIT_ITEM = 6;
+  let newPosts;
+
+  if (curPage === 1) {
+    newPosts = posts.slice(0, LIMIT_ITEM);
+  } else {
+    const startItem = (curPage - 1) * LIMIT_ITEM;
+    newPosts = posts.slice(startItem, startItem + LIMIT_ITEM);
+  }
+
+  const pageCount = Math.ceil(posts.length / LIMIT_ITEM);
+
+  return { newPosts, pageCount, curPage, setCurPage };
+}

--- a/hooks/useSearchPosts.ts
+++ b/hooks/useSearchPosts.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+
+export default function useSearchPosts(allPosts) {
+  const [searchTitle, setSearchTitle] = useState("");
+  const [searchPosts, setSearchPosts] = useState([]);
+
+  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTitle(e.target.value);
+  };
+
+  const getSearchPosts = () => {
+    if (searchTitle !== "") {
+      const tmp = [];
+      allPosts.map((post) => {
+        const regex = new RegExp(searchTitle, "gim");
+        if (regex.test(post.title)) {
+          tmp.push(post);
+        }
+      });
+      setSearchPosts(tmp);
+    } else {
+      setSearchPosts([]);
+    }
+  };
+
+  return { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts };
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,12 +2,10 @@ import "styles/globals.css";
 import type { AppProps } from "next/app";
 import { ThemeProvider } from "next-themes";
 
-function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class">
       <Component {...pageProps} />
     </ThemeProvider>
   );
 }
-
-export default MyApp;

--- a/pages/algorithm/[slug].tsx
+++ b/pages/algorithm/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allAlgorithms } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/algorithm/[slug].tsx
+++ b/pages/algorithm/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allAlgorithms } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -32,7 +34,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -49,5 +51,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/algorithm/[slug].tsx
+++ b/pages/algorithm/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allAlgorithms } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,17 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
-
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/algorithm/index.tsx
+++ b/pages/algorithm/index.tsx
@@ -11,9 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allAlgorithms } from "contentlayer/generated";
 
-const Algorithms = ({
+export default function Algorithms({
   posts,
-}: InferGetStaticPropsType<typeof getStaticProps>) => {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -61,7 +61,7 @@ const Algorithms = ({
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   let posts = allAlgorithms.sort(
@@ -74,5 +74,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default Algorithms;

--- a/pages/algorithm/index.tsx
+++ b/pages/algorithm/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allAlgorithms } from "contentlayer/generated";
 
 export default function Algorithms({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allAlgorithms.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allAlgorithms);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/pages/algorithm/index.tsx
+++ b/pages/algorithm/index.tsx
@@ -5,6 +5,9 @@ import PostList from "components/PostList";
 import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allAlgorithms } from "contentlayer/generated";
 
@@ -33,25 +36,35 @@ const Algorithms = ({
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const algorithm = posts.filter((post) => post.category === "algorithm");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={algorithm} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );
 };
 
 export const getStaticProps = async () => {
-  const posts = allAlgorithms.sort(
+  let posts = allAlgorithms.sort(
     (a, b) => Number(new Date(b.date)) - Number(new Date(a.date))
   );
 

--- a/pages/git/[slug].tsx
+++ b/pages/git/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allGits } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,17 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
-
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/git/[slug].tsx
+++ b/pages/git/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allGits } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/git/[slug].tsx
+++ b/pages/git/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allGits } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -32,7 +34,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -49,5 +51,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/git/index.tsx
+++ b/pages/git/index.tsx
@@ -11,7 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allGits } from "contentlayer/generated";
 
-const Git = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Git({
+  posts,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -59,7 +61,7 @@ const Git = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allGits.sort(
@@ -72,5 +74,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default Git;

--- a/pages/git/index.tsx
+++ b/pages/git/index.tsx
@@ -5,6 +5,9 @@ import PostList from "components/PostList";
 import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allGits } from "contentlayer/generated";
 
@@ -31,18 +34,28 @@ const Git = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const git = posts.filter((post) => post.category === "git");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={git} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/git/index.tsx
+++ b/pages/git/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allGits } from "contentlayer/generated";
 
 export default function Git({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allGits.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allGits);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import Container from "../components/Container";
 
-const Home = () => {
+export default function Home() {
   return (
     <Container>
       <div className={`my-5 w-full`}>
@@ -53,6 +53,4 @@ const Home = () => {
       </div>
     </Container>
   );
-};
-
-export default Home;
+}

--- a/pages/js/[slug].tsx
+++ b/pages/js/[slug].tsx
@@ -1,6 +1,7 @@
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allJs } from "contentlayer/generated";
 import { InferGetStaticPropsType } from "next";
@@ -18,16 +19,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/js/[slug].tsx
+++ b/pages/js/[slug].tsx
@@ -6,7 +6,9 @@ import { allJs } from "contentlayer/generated";
 import { InferGetStaticPropsType } from "next";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -30,7 +32,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -47,5 +49,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/js/[slug].tsx
+++ b/pages/js/[slug].tsx
@@ -3,6 +3,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allJs } from "contentlayer/generated";
 import { InferGetStaticPropsType } from "next";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -11,11 +13,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/js/index.tsx
+++ b/pages/js/index.tsx
@@ -11,9 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allJs } from "contentlayer/generated";
 
-const JavaScript = ({
+export default function JavaScript({
   posts,
-}: InferGetStaticPropsType<typeof getStaticProps>) => {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -61,7 +61,7 @@ const JavaScript = ({
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allJs.sort(
@@ -73,5 +73,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default JavaScript;

--- a/pages/js/index.tsx
+++ b/pages/js/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allJs } from "contentlayer/generated";
 
 export default function JavaScript({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allJs.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allJs);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/pages/js/index.tsx
+++ b/pages/js/index.tsx
@@ -5,6 +5,9 @@ import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import PostList from "components/PostList";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allJs } from "contentlayer/generated";
 
@@ -33,11 +36,13 @@ const JavaScript = ({
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
-
-  const javaScript = posts.filter((post) => post.category === "js");
 
   return (
     <Container>
@@ -45,7 +50,14 @@ const JavaScript = ({
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={javaScript} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/next/[slug].tsx
+++ b/pages/next/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allNexts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/next/[slug].tsx
+++ b/pages/next/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allNexts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -31,7 +33,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -48,5 +50,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/next/[slug].tsx
+++ b/pages/next/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allNexts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,16 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/next/index.tsx
+++ b/pages/next/index.tsx
@@ -5,6 +5,9 @@ import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import PostList from "components/PostList";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allNexts } from "contentlayer/generated";
 
@@ -31,18 +34,28 @@ const NextJs = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const nextjs = posts.filter((post) => post.category === "nextjs");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={nextjs} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/next/index.tsx
+++ b/pages/next/index.tsx
@@ -11,7 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allNexts } from "contentlayer/generated";
 
-const NextJs = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function NextJs({
+  posts,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -59,7 +61,7 @@ const NextJs = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allNexts.sort(
@@ -71,5 +73,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default NextJs;

--- a/pages/next/index.tsx
+++ b/pages/next/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allNexts } from "contentlayer/generated";
 
 export default function NextJs({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allNexts.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allNexts);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/pages/other/[slug].tsx
+++ b/pages/other/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allOthers } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,16 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/other/[slug].tsx
+++ b/pages/other/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allOthers } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -31,7 +33,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -48,5 +50,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/other/[slug].tsx
+++ b/pages/other/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allOthers } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/other/index.tsx
+++ b/pages/other/index.tsx
@@ -11,7 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allOthers } from "contentlayer/generated";
 
-const Other = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Other({
+  posts,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -59,7 +61,7 @@ const Other = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allOthers.sort(
@@ -72,5 +74,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default Other;

--- a/pages/other/index.tsx
+++ b/pages/other/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allOthers } from "contentlayer/generated";
 
 export default function Other({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allOthers.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allOthers);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/pages/other/index.tsx
+++ b/pages/other/index.tsx
@@ -5,6 +5,9 @@ import PostList from "components/PostList";
 import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allOthers } from "contentlayer/generated";
 
@@ -31,18 +34,28 @@ const Other = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const other = posts.filter((post) => post.category === "other");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={other} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/react/[slug].tsx
+++ b/pages/react/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allReacts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,16 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/react/[slug].tsx
+++ b/pages/react/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allReacts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -31,7 +33,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -48,5 +50,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/react/[slug].tsx
+++ b/pages/react/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allReacts } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/react/index.tsx
+++ b/pages/react/index.tsx
@@ -11,7 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allReacts } from "contentlayer/generated";
 
-const React = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function React({
+  posts,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -58,7 +60,7 @@ const React = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allReacts.sort(
@@ -71,5 +73,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default React;

--- a/pages/react/index.tsx
+++ b/pages/react/index.tsx
@@ -8,33 +8,16 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allReacts } from "contentlayer/generated";
 
 export default function React({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allReacts);
 
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allReacts.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,
   });

--- a/pages/react/index.tsx
+++ b/pages/react/index.tsx
@@ -5,6 +5,9 @@ import PostList from "components/PostList";
 import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allReacts } from "contentlayer/generated";
 
@@ -30,19 +33,28 @@ const React = ({ posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
       setSearchPosts([]);
     }
   };
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
 
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const react = posts.filter((post) => post.category === "react");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={react} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/types/[slug].tsx
+++ b/pages/types/[slug].tsx
@@ -7,7 +7,9 @@ import TopBtn from "components/TopBtn";
 import { allTypes } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
-const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
+export default function Post({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
   const customMeta = {
     title: post.title,
@@ -31,7 +33,7 @@ const Post = ({ post }: InferGetStaticPropsType<typeof getStaticProps>) => {
       <Comments />
     </Container>
   );
-};
+}
 
 export const getStaticPaths = async () => {
   return {
@@ -48,5 +50,3 @@ export const getStaticProps = async ({ params }) => {
     },
   };
 };
-
-export default Post;

--- a/pages/types/[slug].tsx
+++ b/pages/types/[slug].tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from "next";
 import Container from "components/Container";
 import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
+import BlogContents from "components/BlogContents";
 
 import { allTypes } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
@@ -19,16 +20,7 @@ export default function Post({
 
   return (
     <Container customMeta={customMeta} className="relative">
-      <article className="mt-10 prose max-w-none">
-        <h1 className="text-green-500 text-center">{post.title}</h1>
-        <h3 className="text-green-600 text-end italic">
-          {post.date.slice(0, 4)}년 {post.date.slice(5, 7)}월
-          {post.date.slice(8, 10)}일
-        </h3>
-        <article className={`w-full dark:text-slate-50 text-neutral-900`}>
-          <MDXComponent />
-        </article>
-      </article>
+      <BlogContents post={post} MDXComponent={MDXComponent} />
       <TopBtn />
       <Comments />
     </Container>

--- a/pages/types/[slug].tsx
+++ b/pages/types/[slug].tsx
@@ -5,6 +5,8 @@ import Comments from "components/Comments";
 import TopBtn from "components/TopBtn";
 import BlogContents from "components/BlogContents";
 
+import { makeMeta } from "utils/makeMeta";
+
 import { allTypes } from "contentlayer/generated";
 import { useMDXComponent } from "next-contentlayer/hooks";
 
@@ -12,11 +14,7 @@ export default function Post({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const MDXComponent = useMDXComponent(post.body.code);
-  const customMeta = {
-    title: post.title,
-    description: post.description,
-    date: new Date(post.date).toISOString(),
-  };
+  const customMeta = makeMeta(post);
 
   return (
     <Container customMeta={customMeta} className="relative">

--- a/pages/types/index.tsx
+++ b/pages/types/index.tsx
@@ -5,6 +5,9 @@ import PostList from "components/PostList";
 import Container from "components/Container";
 import SeachBar from "components/SeachBar";
 import TopBtn from "components/TopBtn";
+import Pagnation from "components/Pagnation";
+
+import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allTypes } from "contentlayer/generated";
 
@@ -33,18 +36,28 @@ const TypeScript = ({
     }
   };
 
+  const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
+    posts,
+  });
+
   useEffect(() => {
     getSearchPosts();
   }, [searchTitle]);
 
-  const type = posts.filter((post) => post.category === "type");
   return (
     <Container>
       <SeachBar
         searchTitle={searchTitle}
         onChangeSearchTitle={onChangeSearchTitle}
       />
-      <PostList searchPosts={searchPosts} posts={type} />
+      <PostList searchPosts={searchPosts} posts={newPosts} />
+      {!searchTitle && (
+        <Pagnation
+          curPage={curPage}
+          pageCount={pageCount}
+          setCurPage={setCurPage}
+        />
+      )}
       <TopBtn />
     </Container>
   );

--- a/pages/types/index.tsx
+++ b/pages/types/index.tsx
@@ -11,9 +11,9 @@ import usePagnationPosts from "hooks/usePagnationPosts";
 
 import { allTypes } from "contentlayer/generated";
 
-const TypeScript = ({
+export default function TypeScript({
   posts,
-}: InferGetStaticPropsType<typeof getStaticProps>) => {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   const [searchTitle, setSearchTitle] = useState("");
   const [searchPosts, setSearchPosts] = useState([]);
 
@@ -61,7 +61,7 @@ const TypeScript = ({
       <TopBtn />
     </Container>
   );
-};
+}
 
 export const getStaticProps = async () => {
   const posts = allTypes.sort(
@@ -74,5 +74,3 @@ export const getStaticProps = async () => {
     },
   };
 };
-
-export default TypeScript;

--- a/pages/types/index.tsx
+++ b/pages/types/index.tsx
@@ -8,33 +8,15 @@ import TopBtn from "components/TopBtn";
 import Pagnation from "components/Pagnation";
 
 import usePagnationPosts from "hooks/usePagnationPosts";
+import useSearchPosts from "hooks/useSearchPosts";
 
 import { allTypes } from "contentlayer/generated";
 
 export default function TypeScript({
   posts,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchPosts, setSearchPosts] = useState([]);
-
-  const onChangeSearchTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTitle(e.target.value);
-  };
-
-  const getSearchPosts = () => {
-    if (searchTitle !== "") {
-      const tmp = [];
-      allTypes.map((post) => {
-        const regex = new RegExp(searchTitle, "gim");
-        if (regex.test(post.title)) {
-          tmp.push(post);
-        }
-      });
-      setSearchPosts(tmp);
-    } else {
-      setSearchPosts([]);
-    }
-  };
+  const { searchTitle, searchPosts, onChangeSearchTitle, getSearchPosts } =
+    useSearchPosts(allTypes);
 
   const { newPosts, pageCount, curPage, setCurPage } = usePagnationPosts({
     posts,

--- a/utils/makeMeta.ts
+++ b/utils/makeMeta.ts
@@ -1,0 +1,7 @@
+export const makeMeta = (post) => {
+  return {
+    title: post.title,
+    description: post.description,
+    date: new Date(post.date).toISOString(),
+  };
+};


### PR DESCRIPTION
- 페이지네이션 구축
- 기존의 포스터의 메타데이터를 만드는 함수를 utils/makeMeta로 모듈화했습니다
- [slug].tsx 파일안 contents를보여주는 부분을 컴포넌트로 만들었습니다
- getSearchPosts 함수를 hook로 만들었습니다
- 모든 최상위 함수는 export default funtion으로 통일시켰습니다
